### PR TITLE
Folding consecutive lines that start with "#"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,26 @@ async function getMultilineCommentRanges(document: vscode.TextDocument): Promise
         multilineCommentRanges.push(range);
     }
 
+    let firstCommentLineNr = -1;
+    for (let lineNr = 0; lineNr < document.lineCount; lineNr++) {
+        const line = document.lineAt(lineNr);
+        if (line.text.trim().startsWith('#')) {
+            if (firstCommentLineNr === -1) {
+                firstCommentLineNr = lineNr;
+            }
+        } else if (firstCommentLineNr != -1) {
+            const lineText = line.text;
+            const startPos = new vscode.Position(firstCommentLineNr, 0);
+            const endPos = new vscode.Position(lineNr-1, lineText.length);    // This line is the first without a comment, so it shouldn't be folded
+            if (lineNr - firstCommentLineNr > 1) {
+                const range = new vscode.Range(startPos, endPos);
+                multilineCommentRanges.push(range);
+            }
+            firstCommentLineNr = -1;
+        }
+
+    }
+
     return multilineCommentRanges;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,10 @@ export function activate(context: vscode.ExtensionContext) {
         await toggleMultilineComments();
     });
 
+    context.subscriptions.push(foldCommand);
+    context.subscriptions.push(unfoldCommand);
+    context.subscriptions.push(toggleCommand);
+
     vscode.languages.registerFoldingRangeProvider('python', {
         provideFoldingRanges(document, context, token) {
             let multilineFoldingRanges = [];
@@ -52,11 +56,6 @@ export function activate(context: vscode.ExtensionContext) {
             return multilineFoldingRanges;
         }
     });
-    
-
-    context.subscriptions.push(foldCommand);
-    context.subscriptions.push(unfoldCommand);
-    context.subscriptions.push(toggleCommand);
 
     // Listen for Python files being opened
     vscode.workspace.onDidOpenTextDocument(document => {
@@ -131,7 +130,6 @@ async function getMultilineCommentRanges(document: vscode.TextDocument): Promise
             }
             firstCommentLineNr = -1;
         }
-
     }
 
     return multilineCommentRanges;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,6 +152,17 @@ vscode.languages.registerFoldingRangeProvider('python', {
     provideFoldingRanges(document, context, token) {
         let multilineFoldingRanges = [];
 
+        // This is getting executed every keystroke, so don't redefine folding ranges unless we've just created a # comment
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return [];
+        }
+        const cursorPosition = editor.selection.active;
+        const lineText = editor.document.lineAt(cursorPosition.line).text;
+        if (!lineText.trim().startsWith('#')) {
+            return [];
+        }
+
         let firstCommentLineNr = -1;
         for (let lineNr = 0; lineNr < document.lineCount; lineNr++) {
             const line = document.lineAt(lineNr);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,4 +126,27 @@ async function toggleMultilineComments() {
     await foldOrUnfoldMultilineComments(newFoldState);
 }
 
+vscode.languages.registerFoldingRangeProvider('python', {
+    provideFoldingRanges(document, context, token) {
+        let multilineFoldingRanges = [];
+
+        let firstCommentLineNr = -1;
+        for (let lineNr = 0; lineNr < document.lineCount; lineNr++) {
+            const line = document.lineAt(lineNr);
+            if (line.text.trim().startsWith('#')) {
+                if (firstCommentLineNr === -1) {
+                    firstCommentLineNr = lineNr;
+                }
+            } else if (firstCommentLineNr != -1) {
+                if (lineNr - firstCommentLineNr > 1) {
+                    multilineFoldingRanges.push(new vscode.FoldingRange(firstCommentLineNr, lineNr-1, vscode.FoldingRangeKind.Region));
+                }
+                firstCommentLineNr = -1;
+            }
+        }
+        return multilineFoldingRanges;
+    }
+});
+
+
 export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,6 +110,7 @@ async function foldOrUnfoldMultilineComments(fold: boolean, editor?: vscode.Text
         return;
     }
 
+    const savedSelection = editor.selection;
     const savedSelections = editor.selections;
     const savedViewState = editor.visibleRanges;
 
@@ -122,6 +123,7 @@ async function foldOrUnfoldMultilineComments(fold: boolean, editor?: vscode.Text
     }
 
     editor.selections = savedSelections;
+    editor.selection = savedSelection;
 
     if (savedViewState.length > 0) {
         editor.revealRange(savedViewState[0], vscode.TextEditorRevealType.AtTop);


### PR DESCRIPTION
Hi,

Sorry - this is one of those unbidden pull requests, but I saw you project and I liked it. However, I don't only want to fold docstrings, but all comments. 

I have a member on my team that loves to comment stuff and he'll happily insert long texts explaining the reasoning behind his decisions. This is.. not.. bad. It's just that he's very particular about line brakes so I typically get 20 lines in the middle of a method I'm trying to debug that all start with "#".

So I added this to you extension. 

The default python language doesn't gorup consecutive lines with "#" as a single comment, so I did. And then I added an auto-fold, the same way you did. 